### PR TITLE
Draft Version 0.9.2

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,7 @@
 {
     "name": "Archive Page",
     "author": "John Navas",
+    "manifest_version": 2,
     "permissions": [
         "activeTab",
         "contextMenus",
@@ -9,7 +10,7 @@
     "optional_permissions": [
         "notifications"
     ],
-    "version": "0.9.1",
+    "version": "0.9.2",
     "description": "Archive webpage with archive.today",
     "background": {
         "scripts": [
@@ -49,5 +50,9 @@
             "description": "Search (Find) archive.today for the current page"
         }
     },
-    "manifest_version": 2
+    "browser_specific_settings": {
+        "gecko": {
+            "strict_min_version": "113.0"
+        }
+    }
 }


### PR DESCRIPTION
A new packaged 0.9.2 version was put into the official repository as of https://github.com/JNavas2/Archive-Page/commit/7fd9d06079d0562c177819e1ef95ab2430c6f21a.

I will probably wait to see for it to be released on AMO before updating the main branch. But here is a PR to do a comparison with the previous draft. Note that the META-INF is missing, as this package is not a full .xpi build.

## Changelog

1. Fallback from `browser` to `chrome` global. (Unclear why, `chrome` is [not used by Firefox](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Chrome_incompatibilities#javascript_apis).)
2. `openerTabId` no longer recorded on new tabs, may affect tab trees. (Potentially done because it [does not exist in Firefox **for Android**](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/tabs/create#browser_compatibility).)
3. 📱 Android support!
4. Option to show notifications on add-on updates.